### PR TITLE
Fix "fatal: could not read Username..."

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -81,6 +81,7 @@ jobs:
         fi
 
         git commit --allow-empty -m "$COMMIT_MSG"
+        git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         git push origin "$branch_name"
 
         pr_number=$(gh pr list --head "$branch_name" --state all --json number --jq '.[0].number' 2>/dev/null || echo "")

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v6
-      with:
-        persist-credentials: false
 
     - name: Check for recent activity
       id: check_activity
@@ -81,7 +79,6 @@ jobs:
         fi
 
         git commit --allow-empty -m "$COMMIT_MSG"
-        git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         git push origin "$branch_name"
 
         pr_number=$(gh pr list --head "$branch_name" --state all --json number --jq '.[0].number' 2>/dev/null || echo "")


### PR DESCRIPTION
The scheduled keep-alive job failed on it's [first run](https://github.com/SteeltoeOSS/NetCoreToolTemplates/actions/runs/23825521252) with:
```
fatal: could not read Username for 'https://github.com/': No such device or address
Error: Process completed with exit code 128.
```

This happens when the job tries to run `git push origin "$branch_name"`, effectively without credentials, because `persist-credentials` is set to `false` and we aren't completely configuring git another way.

We should be able to fix this by either:
- removing this:
  ```
  with:
    persist-credentials: false
  ```
- adding this:
  ```
  git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
  ```