### PR TITLE
Fixed: broken tests due to transitive vulnerable dependencies

### DIFF
--- a/test/NetCoreTool.Template.WebApi.Test/ProjectOptionTest.cs
+++ b/test/NetCoreTool.Template.WebApi.Test/ProjectOptionTest.cs
@@ -43,7 +43,7 @@ namespace Steeltoe.NetCoreTool.Template.WebApi.Test
 
             Logger.WriteLine("building project");
             await CreateEditorConfigForUnnecessaryUsings(sandbox);
-            var buildCmd = "dotnet build /p:TreatWarningsAsErrors=True /p:EnforceCodeStyleInBuild=True /p:GenerateDocumentationFile=True";
+            var buildCmd = "dotnet build /p:TreatWarningsAsErrors=True /p:EnforceCodeStyleInBuild=True /p:GenerateDocumentationFile=True /p:NuGetAuditMode=direct";
             await sandbox.ExecuteCommandAsync(buildCmd, false);
             sandbox.CommandExitCode.Should().Be(0, $"build should succeed, while output was:{Environment.NewLine}{sandbox.CommandOutput}");
         }


### PR DESCRIPTION
Fix for failed run at https://github.com/SteeltoeOSS/NetCoreToolTemplates/actions/runs/25636308634.

```
Error: Expected sandbox.CommandExitCode to be 0 because build should succeed, while output was:
  Determining projects to restore...
/tmp/DotNetNewTemplatesSandboxes/P_67a57604db3d4862a0c48a029e3d6b52/P_67a57604db3d4862a0c48a029e3d6b52.csproj : error NU1902: Warning As Error: Package 'SharpCompress' 0.30.1 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-6c8g-7p36-r338 [/tmp/DotNetNewTemplatesSandboxes/P_67a57604db3d4862a0c48a029e3d6b52/P_67a57604db3d4862a0c48a029e3d6b52.slnx]
/tmp/DotNetNewTemplatesSandboxes/P_67a57604db3d4862a0c48a029e3d6b52/P_67a57604db3d4862a0c48a029e3d6b52.csproj : error NU1903: Warning As Error: Package 'Snappier' 1.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-pggp-6c3x-2xmx [/tmp/DotNetNewTemplatesSandboxes/P_67a57604db3d4862a0c48a029e3d6b52/P_67a57604db3d4862a0c48a029e3d6b52.slnx]
  Failed to restore /tmp/DotNetNewTemplatesSandboxes/P_67a57604db3d4862a0c48a029e3d6b52/P_67a57604db3d4862a0c48a029e3d6b52.csproj (in 780 ms).

Build FAILED.
```